### PR TITLE
Removed elevation property that was creating visual bug

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -105,7 +105,7 @@ class Button extends React.Component<Props, State> {
   };
 
   state = {
-    elevation: new Animated.Value(this.props.mode === 'contained' ? 0 : 0),
+    elevation: new Animated.Value(0),
   };
 
   _handlePressIn = () => {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -105,7 +105,7 @@ class Button extends React.Component<Props, State> {
   };
 
   state = {
-    elevation: new Animated.Value(this.props.mode === 'contained' ? 2 : 0),
+    elevation: new Animated.Value(this.props.mode === 'contained' ? 0 : 0),
   };
 
   _handlePressIn = () => {


### PR DESCRIPTION
Removed elevation which was meant to create a shadow effect. But:
- we don't need a shadow effect for Nest Wealth
- it was creating a bug on Android where the shadow would be visible inside the button when it was toggled from 'contained' to 'outlined'
![51892054_245649726370649_5250078077425287168_n](https://user-images.githubusercontent.com/32785837/52640605-dbe14a80-2ea4-11e9-9d85-f852495a98fd.jpg)
![51757608_1319500504857733_1137377867638767616_n](https://user-images.githubusercontent.com/32785837/52640616-e26fc200-2ea4-11e9-94fa-d8494a973f03.jpg)
Bottom image is before, top image is after.